### PR TITLE
Fix listBlobs

### DIFF
--- a/R/storage_service.R
+++ b/R/storage_service.R
@@ -144,7 +144,7 @@ callStorage <- function(request, credentials, body = NULL, ...){
   }
 }
 
-listBlobs <- function(containerName, sasToken = list(), ...){
+listBlobs <- function(containerName, sasToken = NULL, ...){
   args <- list(...)
 
   if(!is.null(args$accountName)){


### PR DESCRIPTION
Function threw an error when no sasToken was supplied as the default was not NULL. The other storage functions have sasToken = NULL which makes this function consistent with the others.