### PR TITLE
Update storage_service.R

### DIFF
--- a/R/storage_service.R
+++ b/R/storage_service.R
@@ -112,7 +112,7 @@ callStorage <- function(request, credentials, body = NULL, ...){
   authString<-paste0("SharedKey ", credentials$name, ":", credentials$signString(stringToSign))
 
   headers['Authorization'] <- authString
-  requestHeaders<-add_headers(.headers = headers, "User-Agent"="rAzureBatch/0.2.0")
+  requestHeaders <- httr::add_headers(.headers = headers, "User-Agent"="rAzureBatch/0.2.0")
 
   config <- getOption("az_config")
   if(!is.null(config) && !is.null(config$settings)){


### PR DESCRIPTION
for a missing ```httr::``` call

I recommend running some test script on a clear R session (!) to detect all such places. Something like this:
```
suppressPackageStartupMessages(foreach)
doAzureParallel::setCredentials("azure/credentials.json")
cluster <- doAzureParallel::makeCluster("azure/cluster.json")
doAzureParallel::registerDoAzureParallel(cluster)
res <- foreach(i=1:4) %dopar% {
    mean(1:3)
}
doAzureParallel::stopCluster(cluster)
```
It will highlight all missing imports