### PR TITLE
User Agent header should use space delimter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rAzureBatch
 Type: Package
 Title: rAzureBatch
-Version: 0.5.3
+Version: 0.5.4
 Author: Brian Hoang
 Maintainer: Brian Hoang <brhoan@microsoft.com>
 Description: The project is for data experts who use R at scale. The project

--- a/R/batch_service.R
+++ b/R/batch_service.R
@@ -51,7 +51,7 @@ prepareBatchRequest <- function(request, credentials) {
     paste0(
       "rAzureBatch/",
       packageVersion("rAzureBatch"),
-      ";",
+      " ",
       "doAzureParallel/",
       packageVersion("doAzureParallel")
     )


### PR DESCRIPTION
Currently the user agent header is using a ';' delimeter, when it should be using a space instead.